### PR TITLE
Add CI workflows for MidiUmpKeyboard and MidiUmpScope

### DIFF
--- a/.github/workflows/build-midiumpkeyboard.yml
+++ b/.github/workflows/build-midiumpkeyboard.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build MidiUmpKeyboard Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./midi-samples
+
+      - name: Build MidiUmpKeyboard app
+        working-directory: ./midi-samples
+        run: ./gradlew :MidiUmpKeyboard:assembleDebug

--- a/.github/workflows/build-midiumpscope.yml
+++ b/.github/workflows/build-midiumpscope.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build MidiUmpScope Sample
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./midi-samples
+
+      - name: Build MidiUmpScope app
+        working-directory: ./midi-samples
+        run: ./gradlew :MidiUmpScope:assembleDebug


### PR DESCRIPTION
This commit adds GitHub Actions workflows to build the MidiUmpKeyboard and MidiUmpScope sample apps. These workflows will automatically build the apps on push and pull request events to the main branch, and can run manually with workflow_dispatch.