### PR TITLE
Remove working-directory from build workflows

### DIFF
--- a/.github/workflows/build-midiumpkeyboard.yml
+++ b/.github/workflows/build-midiumpkeyboard.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./midi-samples
 
       - name: Build MidiUmpKeyboard app
-        working-directory: ./midi-samples
         run: ./gradlew :MidiUmpKeyboard:assembleDebug

--- a/.github/workflows/build-midiumpscope.yml
+++ b/.github/workflows/build-midiumpscope.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./midi-samples
 
       - name: Build MidiUmpScope app
-        working-directory: ./midi-samples
         run: ./gradlew :MidiUmpScope:assembleDebug


### PR DESCRIPTION
This commit removes the `working-directory` directives from the GitHub Actions workflows for building the MidiUmpKeyboard and MidiUmpScope sample apps. This ensures that the Gradle tasks are executed in the correct directory.